### PR TITLE
handles events of type -99

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,7 @@
+Version 2.5
+- ENH: handles events of type -99 if EEGLAB option set
+- ENH: further checks when processing datasets with boundaries
+
 Version 2.4
 - BUG: new fix command line call for backward compatibility in pop_eegfiltnew.m
 

--- a/eegplugin_firfilt.m
+++ b/eegplugin_firfilt.m
@@ -31,7 +31,7 @@
 
 function vers = eegplugin_firfilt(fig, trystrs, catchstrs)
 
-    vers = 'firfilt2.4';
+    vers = 'firfilt2.5';
     if nargin < 3
         error('eegplugin_firfilt requires 3 arguments');
     end

--- a/findboundaries.m
+++ b/findboundaries.m
@@ -32,27 +32,40 @@
 
 function boundaries = findboundaries(event)
 
-if isfield(event, 'type') & isfield(event, 'latency') & cellfun('isclass', {event.type}, 'char')
-
-    % Boundary event indices
-    boundaries = strmatch('boundary', {event.type});
-
-    % Boundary event latencies
-    boundaries = [event(boundaries).latency];
-
-    % Shift boundary events to epoch onset
-    boundaries = fix(boundaries + 0.5);
-
-    % Remove duplicate boundary events
-    boundaries = unique(boundaries);
-
-    % Epoch onset at first sample?
-    if isempty(boundaries) || boundaries(1) ~= 1
-        boundaries = [1 boundaries];
-    end
-
-else
+if isempty(event) || ~isfield(event, 'type') || ~isfield(event, 'latency') 
 
     boundaries = 1;
+
+else
+    
+    if ischar(event(1).type)
+        % Boundary event indices
+        boundaries = strmatch('boundary', {event.type});
+    else
+        eeglab_options;
+        if option_boundary99
+            boundaries = find( [ event.type ] == -99);
+        end
+    end
+
+    if ~isempty(boundaries)
+
+        % Boundary event latencies
+        boundaries = [event(boundaries).latency];
+
+        % Shift boundary events to epoch onset
+        boundaries = fix(boundaries + 0.5);
+
+        % Remove duplicate boundary events
+        boundaries = unique(boundaries);
+
+        if boundaries(1) ~= 1 
+            boundaries = [ 1 boundaries ];
+        end
+    else
+
+        boundaries = 1;
+    
+    end
 
 end

--- a/findboundaries.m
+++ b/findboundaries.m
@@ -32,40 +32,31 @@
 
 function boundaries = findboundaries(event)
 
-if isempty(event) || ~isfield(event, 'type') || ~isfield(event, 'latency') 
+if isfield(event, 'type') && isfield(event, 'latency')
 
-    boundaries = 1;
-
-else
-    
-    if ischar(event(1).type)
-        % Boundary event indices
+    % Boundary event indices
+    if all(cellfun('isclass', {event.type}, 'char'))
         boundaries = strmatch('boundary', {event.type});
     else
-        eeglab_options;
-        if option_boundary99
-            boundaries = find( [ event.type ] == -99);
-        end
+        boundaries = find([ event.type ] == -99);
     end
 
-    if ~isempty(boundaries)
+    % Boundary event latencies
+    boundaries = [event(boundaries).latency];
 
-        % Boundary event latencies
-        boundaries = [event(boundaries).latency];
+    % Shift boundary events to epoch onset
+    boundaries = fix(boundaries + 0.5);
 
-        % Shift boundary events to epoch onset
-        boundaries = fix(boundaries + 0.5);
+    % Remove duplicate boundary events
+    boundaries = unique(boundaries);
 
-        % Remove duplicate boundary events
-        boundaries = unique(boundaries);
-
-        if boundaries(1) ~= 1 
-            boundaries = [ 1 boundaries ];
-        end
-    else
-
-        boundaries = 1;
-    
+    % Epoch onset at first sample?
+    if isempty(boundaries) || boundaries(1) ~= 1
+        boundaries = [1 boundaries];
     end
+
+else
+
+    boundaries = 1;
 
 end


### PR DESCRIPTION
- ENH: handles events of type -99 if EEGLAB option set (for ERPLAB compatibility)
- ENH: further checks when processing datasets with boundaries (for example some datasets might not contain a boundary event at latency 0.5. In this case the first segment was not filtered).