### PR TITLE
Update firfiltsplit.m

### DIFF
--- a/firfiltsplit.m
+++ b/firfiltsplit.m
@@ -70,7 +70,7 @@ if EEG.trials > 1 % Epoched data
 else % Continuous data
     dcArray = findboundaries(EEG.event);
     dcArray = dcArray( dcArray >= 1 & dcArray <= EEG.pnts ); % Assert DC offset events are within data range
-    dcArray = [ dcArray EEG.pnts + 1 ];
+    if dcArray(end) < EEG.pnts, dcArray = [dcArray, EEG.pnts + 1];
 end
 
 % Loop over continuous segments


### PR DESCRIPTION
Add an end marker only if the last found boundary is at a point / sample that is below the last sampling point of the data (I already cut out periods that are not part of the experiment during import and then, FIRFILTSPLIT throws an error.